### PR TITLE
Update for PureScript 0.15

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
         with:
           purescript: "0.15.0"
           purs-tidy: "0.8.0"
-          spago: "0.20.8"
+          spago: "0.20.9"
 
       - name: Build source
         run: spago build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,28 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: purescript-contrib/setup-purescript@main
+        with:
+          purescript: "0.15.0"
+          purs-tidy: "0.8.0"
+          spago: "0.20.8"
+
+      - name: Build source
+        run: spago build
+
+      - name: Run tests
+        run: spago test --no-install
+
+      - name: Verify formatting
+        run: purs-tidy check src test

--- a/.tidyrc.json
+++ b/.tidyrc.json
@@ -1,0 +1,10 @@
+{
+  "importSort": "ide",
+  "importWrap": "source",
+  "indent": 2,
+  "operatorsFile": null,
+  "ribbon": 1,
+  "typeArrowPlacement": "first",
+  "unicode": "never",
+  "width": null
+}

--- a/packages.dhall
+++ b/packages.dhall
@@ -1,5 +1,6 @@
 let upstream =
-      https://github.com/purescript/package-sets/releases/download/psc-0.14.3-20210825/packages.dhall sha256:eee0765aa98e0da8fc414768870ad588e7cada060f9f7c23c37385c169f74d9f
+      https://github.com/purescript/package-sets/releases/download/psc-0.15.0-20220509/packages.dhall
+        sha256:d4c1a03606efdbb7bb7745a9d3aa908cb1ba5611921373659a4c7bf1c41c106c
 
 let overrides = {=}
 

--- a/spago.dhall
+++ b/spago.dhall
@@ -1,8 +1,6 @@
-{-
-Welcome to a Spago project!
-You can edit this file as you like.
--}
-{ name = "my-project"
+{ name = "node-glob-basic"
+, license = "MIT"
+, repository = "https://github.com/natefaubion/purescript-node-glob-basic.git"
 , dependencies =
   [ "aff"
   , "console"


### PR DESCRIPTION
This updates the dependencies for the library to PureScript 0.15, and also adds CI and purs-tidy to the project. This library doesn't support Bower users, so the major dependency bump doesn't necessarily require a library major version, but under SemVer it likely should because dependencies have moved major versions.